### PR TITLE
Allow min_query_length=0 for external_select

### DIFF
--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -277,7 +277,7 @@ class MultiStaticSelect(StaticSelectBase):
 
 
 class ExternalSelectBase(Select):
-    min_query_length: Optional[int] = Field(None, gt=0)
+    min_query_length: Optional[int] = Field(None, ge=0)
 
 
 class ExternalSelect(ExternalSelectBase):


### PR DESCRIPTION
Slack allows min_query_length to be set to 0.  Currently, blockkit does not allow 0 to be defined.