### PR TITLE
Add number input support.

### DIFF
--- a/blockkit/blocks.py
+++ b/blockkit/blocks.py
@@ -23,6 +23,7 @@ from blockkit.elements import (
     StaticSelect,
     Timepicker,
     UsersSelect,
+    NumberInput,
 )
 from blockkit.objects import MarkdownText, PlainText
 from blockkit.validators import validate_text_length, validator
@@ -131,6 +132,7 @@ InputElement = Union[
     ChannelsSelect,
     MultiChannelsSelect,
     DatePicker,
+    NumberInput,
 ]
 
 

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -43,6 +43,7 @@ __all__ = [
     "StaticSelect",
     "Timepicker",
     "UsersSelect",
+    "NumberInput",
 ]
 
 
@@ -604,3 +605,40 @@ class Timepicker(FocusableElement):
             confirm=confirm,
             focus_on_load=focus_on_load,
         )
+
+
+class NumberInput(FocusableElement):
+    type: str = "number_input"
+    placeholder: Union[PlainText, str, None] = None
+    initial_value: Optional[str] = Field(None, min_length=1)
+    is_decimal_allowed: bool = True
+    min_value: Optional[str] = Field(None)
+    max_value: Optional[str] = Field(None)
+    dispatch_action_config: Optional[DispatchActionConfig] = None
+
+    def __init__(
+        self,
+        *,
+        action_id: Optional[str] = None,
+        placeholder: Union[PlainText, str, None] = None,
+        initial_value: Optional[str] = None,
+        is_decimal_allowed: bool,
+        min_value: Optional[str] = None,
+        max_value: Optional[str] = None,
+        dispatch_action_config: Optional[DispatchActionConfig] = None,
+        focus_on_load: Optional[bool] = None,
+    ):
+        super().__init__(
+            action_id=action_id,
+            placeholder=placeholder,
+            initial_value=initial_value,
+            is_decimal_allowed=is_decimal_allowed,
+            min_value=min_value,
+            max_value=max_value,
+            dispatch_action_config=dispatch_action_config,
+            focus_on_load=focus_on_load,
+        )
+
+    _validate_placeholder = validator(
+        "placeholder", validate_text_length, max_length=150
+    )


### PR DESCRIPTION
[Number inputs](https://api.slack.com/reference/block-kit/block-elements#number) are currently not supported.
These are a input type available in Modals.

I am a rank amateur and this PR definitely isn't the final solution.
This is merely the minimum amount of code that I needed to get a `number_input` element working for my application.

In particular:

* I couldn't figure out how to get `min value` and `max value` to accept `int` / `float` arguments, yet output `str` in the final output. The [Slack API docs](https://api.slack.com/reference/block-kit/block-elements#number__fields) specify that both `min_value` and `max_value` must be strings.
* I am not sufficiently familiar with Pydantic to implement the validation that `min_value < max_value` as required by the [Slack API docs](https://api.slack.com/reference/block-kit/block-elements#number__fields).
* I haven't written any tests for this.