### PR TITLE
Renaming: Timepicker -> TimePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here's the list of types of components and corresponding classes:
 | channels_select            | ChannelsSelect           |
 | conversations_select       | ConversationsSelect      |
 | external_select            | ExternalSelect           |
-| timepicker                 | Timepicker               |
+| timepicker                 | TimePicker               |
 
 ### Composition objects
 

--- a/blockkit/blocks.py
+++ b/blockkit/blocks.py
@@ -21,7 +21,7 @@ from blockkit.elements import (
     PlainTextInput,
     RadioButtons,
     StaticSelect,
-    Timepicker,
+    TimePicker,
     UsersSelect,
     NumberInput,
 )
@@ -46,7 +46,7 @@ ActionElement = Union[
     MultiChannelsSelect,
     Overflow,
     RadioButtons,
-    Timepicker,
+    TimePicker,
 ]
 
 
@@ -184,7 +184,7 @@ AccessoryElement = Union[
     MultiChannelsSelect,
     Overflow,
     RadioButtons,
-    Timepicker,
+    TimePicker,
 ]
 
 

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -41,7 +41,7 @@ __all__ = [
     "PlainTextInput",
     "RadioButtons",
     "StaticSelect",
-    "Timepicker",
+    "TimePicker",
     "UsersSelect",
     "NumberInput",
 ]
@@ -578,7 +578,7 @@ class RadioButtons(FocusableElement):
         return values
 
 
-class Timepicker(FocusableElement):
+class TimePicker(FocusableElement):
     type: str = "timepicker"
     placeholder: Union[PlainText, str, None] = None
     initial_time: Optional[time] = None

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -16,7 +16,7 @@ from blockkit.elements import (
     PlainTextInput,
     RadioButtons,
     StaticSelect,
-    Timepicker,
+    TimePicker,
     UsersSelect,
 )
 from blockkit.objects import (
@@ -1332,7 +1332,7 @@ def test_radio_buttons_initial_options_arent_within_options_raise_exception():
 
 
 def test_builds_timepicker():
-    assert Timepicker(
+    assert TimePicker(
         action_id="action_id",
         placeholder=PlainText(text="placeholder"),
         initial_time="22:55",
@@ -1360,14 +1360,14 @@ def test_builds_timepicker():
 
 def test_timepicker_empty_action_id_raises_exception():
     with pytest.raises(ValidationError):
-        Timepicker(action_id="")
+        TimePicker(action_id="")
 
 
 def test_timepicker_excessive_action_id_raises_exception():
     with pytest.raises(ValidationError):
-        Timepicker(action_id="a" * 256)
+        TimePicker(action_id="a" * 256)
 
 
 def test_timepicker_excessive_placeholder_raises_exception():
     with pytest.raises(ValidationError):
-        Timepicker(placeholder=PlainText(text="p" * 151))
+        TimePicker(placeholder=PlainText(text="p" * 151))


### PR DESCRIPTION
## Purpose
Rename class `blockkit.elements.Timepicker` to `blockkit.elements.TimePicker` to follow naming convention (which corresponds to Slack's "[Time Picker](https://api.slack.com/reference/block-kit/block-elements#timepicker)" component).