### PR TITLE
"Datetime Picker" Element Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Here's the list of types of components and corresponding classes:
 | button                     | Button                   |
 | checkboxes                 | Checkboxes               |
 | datepicker                 | DatePicker               |
+| datetimepicker             | DatetimePicker           |
 | type                       | Image                    |
 | multi_static_select        | MultiStaticSelect        |
 | multi_users_select         | MultiUsersSelect         |

--- a/blockkit/blocks.py
+++ b/blockkit/blocks.py
@@ -10,6 +10,7 @@ from blockkit.elements import (
     Checkboxes,
     ConversationsSelect,
     DatePicker,
+    DatetimePicker,
     ExternalSelect,
     Image,
     MultiChannelsSelect,
@@ -34,6 +35,7 @@ ActionElement = Union[
     Button,
     Checkboxes,
     DatePicker,
+    DatetimePicker,
     StaticSelect,
     MultiStaticSelect,
     ExternalSelect,
@@ -132,6 +134,7 @@ InputElement = Union[
     ChannelsSelect,
     MultiChannelsSelect,
     DatePicker,
+    DatetimePicker,
     NumberInput,
 ]
 

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import date, time
+from datetime import date, time, datetime
 from typing import Dict, List, Optional, Union
 
 from pydantic import Field, root_validator
@@ -19,6 +19,7 @@ from blockkit.objects import (
 from blockkit.validators import (
     SlackUrl,
     validate_date,
+    validate_datetime,
     validate_text_length,
     validate_time,
     validator,
@@ -30,6 +31,7 @@ __all__ = [
     "Checkboxes",
     "ConversationsSelect",
     "DatePicker",
+    "DatetimePicker",
     "ExternalSelect",
     "Image",
     "MultiChannelsSelect",
@@ -152,6 +154,28 @@ class DatePicker(FocusableElement):
     )
     _validate_initial_date = validator("initial_date", validate_date)
 
+
+class DatetimePicker(FocusableElement):
+    type: str = "datetimepicker"
+    initial_date_time: Union[int, datetime, None] = None
+    confirm: Optional[Confirm] = None
+
+    _validate_initial_datetime = validator("initial_date_time", validate_datetime)
+
+    def __init__(
+        self,
+        *,
+        action_id: Optional[str] = None,
+        initial_date_time: Optional[Union[int, datetime]] = None,
+        confirm: Optional[Confirm] = None,
+        focus_on_load: Optional[bool] = None,
+    ):
+        super().__init__(
+            action_id=action_id,
+            initial_date_time=initial_date_time,
+            confirm=confirm,
+            focus_on_load=focus_on_load,
+        )
 
 class Image(Component):
     type: str = "image"

--- a/blockkit/validators.py
+++ b/blockkit/validators.py
@@ -1,4 +1,4 @@
-from datetime import date, time
+from datetime import date, time, datetime
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
 from pydantic import AnyUrl
@@ -37,6 +37,16 @@ def validate_date(v: date) -> Optional[str]:
 def validate_time(v: time) -> Optional[str]:
     if v is not None:
         return v.strftime("%H:%M")
+    return v
+
+
+def validate_datetime(v: Union[int, datetime]) -> Optional[int]:
+    if v is not None:
+        if type(v) == datetime:
+            return int(v.timestamp())
+        else:
+            _ = datetime.fromtimestamp(v)
+            return v
     return v
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest==6.2.5
 pydantic==1.8.2
 black==21.11b1
+python-dateutil==2.8.2

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,10 +1,13 @@
+from datetime import datetime
 import pytest
+from dateutil.tz import gettz
 from blockkit.elements import (
     Button,
     ChannelsSelect,
     Checkboxes,
     ConversationsSelect,
     DatePicker,
+    DatetimePicker,
     ExternalSelect,
     Image,
     MultiChannelsSelect,
@@ -234,6 +237,49 @@ def test_datepicker_excessive_placeholder_raises_exception():
 def test_datepicker_invalid_initial_date_raises_exception():
     with pytest.raises(ValidationError):
         DatePicker(initial_date="YEAR-MON-DAY")
+
+
+def test_builds_datetimepicker():
+    assert DatetimePicker(
+        action_id="action_id",
+        initial_date_time=datetime(
+            year=2023, month=1, day=2, hour=3, minute=4, tzinfo=gettz("America/New_York"),
+        ),
+        confirm=Confirm(
+            title=PlainText(text="title"),
+            text=MarkdownText(text="text"),
+            confirm=PlainText(text="confirm"),
+            deny=PlainText(text="deny"),
+        ),
+        focus_on_load=True,
+    ).build() == {
+        "type": "datetimepicker",
+        "action_id": "action_id",
+        "placeholder": {"type": "plain_text", "text": "placeholder"},
+        "initial_date_time": 1672646640,
+        "confirm": {
+            "title": {"type": "plain_text", "text": "title"},
+            "text": {"type": "mrkdwn", "text": "text"},
+            "confirm": {"type": "plain_text", "text": "confirm"},
+            "deny": {"type": "plain_text", "text": "deny"},
+        },
+        "focus_on_load": True,
+    }
+
+
+def test_datetimepicker_empty_action_id_raises_exception():
+    with pytest.raises(ValidationError):
+        DatetimePicker(action_id="")
+
+
+def test_datetimepicker_excessive_action_id_raises_exception():
+    with pytest.raises(ValidationError):
+        DatetimePicker(action_id="a" * 256)
+
+
+def test_datetimepicker_invalid_initial_datetime_raises_exception():
+    with pytest.raises(ValidationError):
+        DatetimePicker(initial_date_time=1672646640123)
 
 
 def test_builds_image():

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -255,7 +255,6 @@ def test_builds_datetimepicker():
     ).build() == {
         "type": "datetimepicker",
         "action_id": "action_id",
-        "placeholder": {"type": "plain_text", "text": "placeholder"},
         "initial_date_time": 1672646640,
         "confirm": {
             "title": {"type": "plain_text", "text": "title"},


### PR DESCRIPTION
## Purpose
Adds support to "[Datetime Picker](https://api.slack.com/reference/block-kit/block-elements#datetimepicker)" element on the builder.
