### PR TITLE
Fix Python 3.6's Environment Issue in GitHub Action Script

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,11 +11,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
-
+        python-version: ["3.7", "3.8", "3.9"]
+        include:
+          - python-version: "3.6"
+            os: ubuntu-20.04
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
## Purpose
Use Ubuntu 20.04 (latest version that supports Py36) as Python 3.6's test environment to avoid build error.

## Reference
 - https://github.com/satyamsoni2211/lazy_alchemy/pull/6