### PR TITLE
Add support for File Input element type

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Here's the list of types of components and corresponding classes:
 | rich_text_preformatted     | RichTextPreformatted     |
 | rich_text_quote            | RichTextQuote            |
 | rich_text_section          | RichTextSection          |
+| file_input                 | FileInput                |
 
 ### Composition objects
 

--- a/blockkit/blocks.py
+++ b/blockkit/blocks.py
@@ -12,6 +12,7 @@ from blockkit.elements import (
     DatePicker,
     DatetimePicker,
     ExternalSelect,
+    FileInput,
     Image,
     MultiChannelsSelect,
     MultiConversationsSelect,
@@ -154,6 +155,7 @@ InputElement = Union[
     DatetimePicker,
     TimePicker,
     NumberInput,
+    FileInput
 ]
 
 

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -723,7 +723,7 @@ class RichTextList(Component):
 class FileInput(FocusableElement):
     type: str = "file_input"
     filetypes: Optional[List[str]] = Field(None)
-    maxfiles: Optional[int] = Field(None)
+    maxfiles: Optional[int] = Field(..., gt=0, le=10)
 
     def __init__(
         self,
@@ -731,15 +731,9 @@ class FileInput(FocusableElement):
         action_id: Optional[str] = None,
         filetypes: Optional[List[str]] = None,
         maxfiles: Optional[int] = None,
-        focus_on_load: Optional[bool] = None,
     ):
         super().__init__(
             action_id=action_id,
             filetypes=filetypes,
             maxfiles=maxfiles,
-            focus_on_load=focus_on_load,
         )
-
-    _validate_maxfiles = validator(
-        "maxfiles", validate_integer_size, min=1, max=10
-    )

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -23,7 +23,6 @@ from blockkit.validators import (
     validate_datetime,
     validate_text_length,
     validate_time,
-    validate_integer_size,
     validator,
 )
 

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -724,7 +724,6 @@ class FileInput(FocusableElement):
     type: str = "file_input"
     filetypes: Optional[List[str]] = Field(None)
     maxfiles: Optional[int] = Field(None)
-    # dispatch_action_config: Optional[DispatchActionConfig] = None
 
     def __init__(
         self,
@@ -732,14 +731,12 @@ class FileInput(FocusableElement):
         action_id: Optional[str] = None,
         filetypes: Optional[List[str]] = None,
         maxfiles: Optional[int] = None,
-        # dispatch_action_config: Optional[DispatchActionConfig] = None,
         focus_on_load: Optional[bool] = None,
     ):
         super().__init__(
             action_id=action_id,
             filetypes=filetypes,
             maxfiles=maxfiles,
-            # dispatch_action_config=dispatch_action_config,
             focus_on_load=focus_on_load,
         )
 

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -719,7 +719,7 @@ class RichTextList(Component):
     ):
         super().__init__(elements=elements, style=style, indent=indent)
 
-class FileInput(FocusableElement):
+class FileInput(ActionableComponent):
     type: str = "file_input"
     filetypes: Optional[List[str]] = Field(None)
     maxfiles: Optional[int] = Field(..., gt=0, le=10)

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -51,6 +51,7 @@ __all__ = [
     "RichTextQuote",
     "RichTextSection",
     "RichTextList",
+    "FileInput"
 ]
 
 
@@ -717,3 +718,26 @@ class RichTextList(Component):
         indent: Optional[int] = None,
     ):
         super().__init__(elements=elements, style=style, indent=indent)
+
+class FileInput(FocusableElement):
+    type: str = "file_input"
+    filetypes: Optional[List[str]] = Field(None)
+    maxfiles: Optional[int] = Field(None)
+    # dispatch_action_config: Optional[DispatchActionConfig] = None
+
+    def __init__(
+        self,
+        *,
+        action_id: Optional[str] = None,
+        filetypes: Optional[List[str]] = None,
+        maxfiles: Optional[int] = None,
+        # dispatch_action_config: Optional[DispatchActionConfig] = None,
+        focus_on_load: Optional[bool] = None,
+    ):
+        super().__init__(
+            action_id=action_id,
+            filetypes=filetypes,
+            maxfiles=maxfiles,
+            # dispatch_action_config=dispatch_action_config,
+            focus_on_load=focus_on_load,
+        )

--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -23,6 +23,7 @@ from blockkit.validators import (
     validate_datetime,
     validate_text_length,
     validate_time,
+    validate_integer_size,
     validator,
 )
 
@@ -741,3 +742,7 @@ class FileInput(FocusableElement):
             # dispatch_action_config=dispatch_action_config,
             focus_on_load=focus_on_load,
         )
+
+    _validate_maxfiles = validator(
+        "maxfiles", validate_integer_size, min=1, max=10
+    )

--- a/blockkit/validators.py
+++ b/blockkit/validators.py
@@ -53,16 +53,3 @@ def validate_datetime(v: Union[int, datetime]) -> Optional[int]:
             _ = datetime.fromtimestamp(v)
             return v
     return v
-
-def validate_integer_size(v: int, min: int, max: int) -> Optional[int]:
-    if v is not None:
-        if v<max and v>min:
-            return v
-        elif v<min:
-            e = ValueError(f"Minimum value is {min}")
-            raise e
-        elif v>max:
-            e = ValueError(f"Maximum value is {max}")
-            raise e
-        
-    return v

--- a/blockkit/validators.py
+++ b/blockkit/validators.py
@@ -53,3 +53,16 @@ def validate_datetime(v: Union[int, datetime]) -> Optional[int]:
             _ = datetime.fromtimestamp(v)
             return v
     return v
+
+def validate_integer_size(v: int, min: int, max: int) -> Optional[int]:
+    if v is not None:
+        if v<max and v>min:
+            return v
+        elif v<min:
+            e = ValueError(f"Minimum value is {min}")
+            raise e
+        elif v>max:
+            e = ValueError(f"Maximum value is {max}")
+            raise e
+        
+    return v

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1564,13 +1564,11 @@ def test_builds_fileinput():
         action_id="action_id",
         filetypes=["file"],
         maxfiles=1,
-        focus_on_load=True
     ).build() == {
         "type": "file_input",
         "action_id": "action_id",
         "filetypes": ["file"],
         "maxfiles": 1,
-        "focus_on_load": True
     }
 
 def test_fileinput_excessive_maxfiles_raises_exception():

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -12,6 +12,7 @@ from blockkit.elements import (
     DatePicker,
     DatetimePicker,
     ExternalSelect,
+    FileInput,
     Image,
     MultiChannelsSelect,
     MultiConversationsSelect,

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1558,3 +1558,21 @@ def test_timepicker_excessive_action_id_raises_exception():
 def test_timepicker_excessive_placeholder_raises_exception():
     with pytest.raises(ValidationError):
         TimePicker(placeholder=PlainText(text="p" * 151))
+
+def test_builds_fileinput():
+    assert FileInput(
+        action_id="action_id",
+        filetypes=["file"],
+        maxfiles=1,
+        focus_on_load=True
+    ).build() == {
+        "type": "file_input",
+        "action_id": "action_id",
+        "filetypes": ["file"],
+        "maxfiles": 1,
+        "focus_on_load": True
+    }
+
+def test_fileinput_excessive_maxfiles_raises_exception():
+    with pytest.raises(ValidationError):
+        FileInput(maxfiles=11)


### PR DESCRIPTION
Slack added a `file_input` input element type with an API update in January 2024. This PR would add support for the `file_input` element in the builder.