### PR TITLE
Resolve incorrect field name error

### DIFF
--- a/blockkit/elements.py
+++ b/blockkit/elements.py
@@ -722,17 +722,17 @@ class RichTextList(Component):
 class FileInput(ActionableComponent):
     type: str = "file_input"
     filetypes: Optional[List[str]] = Field(None)
-    maxfiles: Optional[int] = Field(..., gt=0, le=10)
+    max_files: Optional[int] = Field(..., gt=0, le=10)
 
     def __init__(
         self,
         *,
         action_id: Optional[str] = None,
         filetypes: Optional[List[str]] = None,
-        maxfiles: Optional[int] = None,
+        max_files: Optional[int] = None,
     ):
         super().__init__(
             action_id=action_id,
             filetypes=filetypes,
-            maxfiles=maxfiles,
+            max_files=max_files,
         )

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1563,14 +1563,14 @@ def test_builds_fileinput():
     assert FileInput(
         action_id="action_id",
         filetypes=["file"],
-        maxfiles=1,
+        max_files=1,
     ).build() == {
         "type": "file_input",
         "action_id": "action_id",
         "filetypes": ["file"],
-        "maxfiles": 1,
+        "max_files": 1,
     }
 
-def test_fileinput_excessive_maxfiles_raises_exception():
+def test_fileinput_excessive_max_files_raises_exception():
     with pytest.raises(ValidationError):
-        FileInput(maxfiles=11)
+        FileInput(max_files=11)


### PR DESCRIPTION
@imryche Huge apologies, somehow I mistyped and did not notice the incorrect field name for Max Files. Quick update to correctly use `max_files` as the field name, tested this is indeed working for me now.