### PR TITLE
Fix the validation logic of the Section component's fields

### DIFF
--- a/blockkit/core.py
+++ b/blockkit/core.py
@@ -2960,7 +2960,7 @@ class Section(Component, BlockIdMixin):
         self.accessory(accessory)
         self.expand(expand)
         self.block_id(block_id)
-        self._add_validator(OnlyOne("text", "fields"))
+        self._add_validator(AtLeastOne("text", "fields"))
 
     def text(self, text: str | Text | None) -> Self:
         if isinstance(text, str):


### PR DESCRIPTION
According to the Block Kit spec, `text` and `fields` in the [Section block](https://api.slack.com/reference/block-kit/blocks#section) aren't mutually exclusive.