### PR TITLE
Increase limits for rich_text_list indent and offset

### DIFF
--- a/blockkit/core.py
+++ b/blockkit/core.py
@@ -2843,10 +2843,10 @@ class RichTextList(Component, RichBorderMixin):
         return self._add_field_value("elements", element)  # type: ignore[attr-defined]
 
     def indent(self, indent: int | None) -> Self:
-        return self._add_field("indent", indent, validators=[Typed(int), Ints(max=6)])
+        return self._add_field("indent", indent, validators=[Typed(int), Ints(max=8)])
 
     def offset(self, offset: int | None) -> Self:
-        return self._add_field("offset", offset, validators=[Typed(int), Ints(max=6)])
+        return self._add_field("offset", offset, validators=[Typed(int), Ints()])
 
 
 class RichTextPreformatted(Component, RichTextElementsMixin, RichBorderMixin):


### PR DESCRIPTION
After playing a bit with https://app.slack.com/block-kit-builder/, it seems that the true indentation limit is 8 (not 6) and that `offset` doesn't really have an upper bound (it stops me after `100000000000000000`, but I think the default max in the `Ints` validator is plenty).