### PR TITLE
Wrap plain strings in Text in Section.add_field()

### DIFF
--- a/blockkit/core.py
+++ b/blockkit/core.py
@@ -3021,7 +3021,9 @@ class Section(Component, BlockIdMixin):
         )
 
     def add_field(self, field: str | Text) -> Self:
-        return self._add_field_value("fields", field)  # type: ignore[attr-defined]
+        return self._add_field_value(
+            "fields", Text(field) if isinstance(field, str) else field
+        )  # type: ignore[attr-defined]
 
     def accessory(self, accessory: SectionElement | None) -> Self:
         return self._add_field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,10 @@ Issues = "https://github.com/imryche/blockkit/issues"
 
 [tool.ruff]
 line-length = 88
-extend-select = ["I", "UP", "ASYNC"]
-extend-ignore = ["UP007"]
 
 [tool.ruff.lint]
 extend-select = ["I", "UP", "E501", "ASYNC"]
+extend-ignore = ["UP007"]
 
 [dependency-groups]
 dev = [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3292,6 +3292,9 @@ class TestSection:
         )
         assert got == want
 
+        got = Section().add_field("Eat me").add_field("Drink me").build()
+        assert got == want
+
 
 class TestTable:
     def test_builds(self):


### PR DESCRIPTION
The `Section.add_field()` signature indicates it accepts both plain strings and `Text` objects; however, plain strings are currently rejected by the validator at runtime. This PR ensures plain strings are wrapped in a `Text` object.

Also ruff linter warnings fixed.