### PR TITLE
Fix #130: Incorrect validation of initial_options for OptionGroup

### DIFF
--- a/blockkit/core.py
+++ b/blockkit/core.py
@@ -244,7 +244,14 @@ class Within(ComponentValidator):
         if not isinstance(source_value, list | tuple | set):
             source_value = [source_value]
 
-        if not set(source_value).issubset(set(target_value)):
+        flattened_target = []
+        for item in target_value:
+            if isinstance(item, OptionGroup):
+                flattened_target.extend(item._get_field_value("options") or [])
+            else:
+                flattened_target.append(item)
+
+        if not set(source_value).issubset(set(flattened_target)):
             raise ComponentValidationError(
                 component,
                 f"'{self.source_field}' has items that aren't "

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1120,16 +1120,8 @@ class TestMultiStaticSelect:
             ],
             "initial_options": [
                 {
-                    "label": {
-                        "type": "plain_text",
-                        "text": "Group 1",
-                    },
-                    "options": [
-                        {
-                            "text": {"type": "plain_text", "text": "Option 1"},
-                            "value": "option_1",
-                        }
-                    ],
+                    "text": {"type": "plain_text", "text": "Option 1"},
+                    "value": "option_1",
                 },
             ],
         }
@@ -1144,9 +1136,7 @@ class TestMultiStaticSelect:
                 ),
             ],
             initial_options=[
-                OptionGroup(
-                    label="Group 1", options=[Option(text="Option 1", value="option_1")]
-                )
+                Option(text="Option 1", value="option_1")
             ],
         ).build()
         assert got == want
@@ -1165,9 +1155,7 @@ class TestMultiStaticSelect:
                 ),
             )
             .add_initial_option(
-                OptionGroup(
-                    label="Group 1", options=[Option(text="Option 1", value="option_1")]
-                )
+                Option(text="Option 1", value="option_1")
             )
             .build()
         )
@@ -1933,16 +1921,8 @@ class TestStaticSelect:
                 },
             ],
             "initial_option": {
-                "label": {
-                    "type": "plain_text",
-                    "text": "Group 1",
-                },
-                "options": [
-                    {
-                        "text": {"type": "plain_text", "text": "Option 1"},
-                        "value": "option_1",
-                    }
-                ],
+                "text": {"type": "plain_text", "text": "Option 1"},
+                "value": "option_1",
             },
         }
         got = StaticSelect(
@@ -1955,9 +1935,7 @@ class TestStaticSelect:
                     label="Group 2", options=[Option(text="Option 2", value="option_2")]
                 ),
             ],
-            initial_option=OptionGroup(
-                label="Group 1", options=[Option(text="Option 1", value="option_1")]
-            ),
+            initial_option=Option(text="Option 1", value="option_1"),
         ).build()
         assert got == want
 
@@ -1975,9 +1953,7 @@ class TestStaticSelect:
                 ),
             )
             .initial_option(
-                OptionGroup(
-                    label="Group 1", options=[Option(text="Option 1", value="option_1")]
-                )
+                Option(text="Option 1", value="option_1")
             )
             .build()
         )


### PR DESCRIPTION
The `initial_option` [field](https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#fields) of a `StaticSelect` should be single option even when the menu contains `OptionGroup`s. This PR fixes the validator and fixes the broken tests that let the old validator pass.

The fix also applies to the validation of `MultiStaticSelect` and the tests of that are fixes as well.